### PR TITLE
catch danbooru cached images

### DIFF
--- a/src/Kaori.js
+++ b/src/Kaori.js
@@ -99,7 +99,7 @@ class Kaori {
 			for (const image of Object.keys(images)) {
 				const key = images[image];
 				key.common = {
-					fileURL: key.file_url.startsWith('/data')
+					fileURL: key.file_url.startsWith('/data') || key.file_url.startsWith('/cached')
 						? `https://danbooru.donmai.us${key.file_url}`
 						: !key.file_url.startsWith('http')
 							? `https:${key.file_url}`


### PR DESCRIPTION
For some posts, danbooru returns links to a cached version.
https://danbooru.donmai.us/cached/data/__mashiro_blan_de_windbloom_my_otome_drawn_by_minato_fumi__ca9d28d3f50c1daaabb3366e4ff58a6a.jpg

This isn't picked up in _common and returns an invalid url for fileUrl in the common object:
https:/cached/data/__tokiha_mai_my_hime_and_my_otome_drawn_by_fukano_youichi__f21840d52497bef5b9b7ca4804f89cee.jpg

This change adds a check for /cached.